### PR TITLE
Improve layout responsiveness and adjust game speed

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,8 @@
     }
     header {
       position: fixed; top: 0; left: 0; right: 0;
-      display: flex; justify-content: space-between; align-items: center;
+      display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center;
+      gap: var(--pad);
       padding: var(--pad) calc(var(--pad) * 1.5);
       background: linear-gradient(180deg, rgba(0,0,0,.35), rgba(0,0,0,0));
       z-index: 5;
@@ -39,7 +40,7 @@
     }
     .brand img { width: 28px; height: 28px; }
     .hud {
-      display: inline-flex; gap: 16px; align-items: center;
+      display: inline-flex; flex-wrap: wrap; gap: 16px; align-items: center; row-gap: 6px;
       font-weight: 600;
       background: rgba(255,255,255,.05);
       padding: 6px 10px; border-radius: 999px; backdrop-filter: blur(6px);

--- a/js/game.js
+++ b/js/game.js
@@ -57,7 +57,7 @@
     particles: [],
     enemyDir: 1,
     enemyStepTimer: 0,
-    enemySpeed: 28, // lower is faster (ms per step)
+    enemySpeed: 40, // lower is faster (ms per step)
     enemyDrop: 16,
     enemyLeft: 60,
     enemyRight: W-60,
@@ -67,7 +67,7 @@
 
   // Entities
   const player = {
-    x: W/2, y: H-80, w: 48, h: 20, speed: 6, inv: 0, tri: 0
+    x: W/2, y: H-80, w: 48, h: 20, speed: 4, inv: 0, tri: 0
   };
 
   function rect(a,b) {
@@ -102,7 +102,7 @@
         });
       }
     }
-    state.enemySpeed = Math.max(12, 34 - level*2);
+    state.enemySpeed = Math.max(18, 46 - level*2);
     state.enemyDir = 1;
     state.enemyLeft = 60;
     state.enemyRight = W-60;
@@ -212,18 +212,18 @@
   function fireBullet() {
     if (state.cooldown > 0) return;
     const bx = player.x + player.w/2 - 2, by = player.y - 14;
-    const bullets = [{x:bx, y:by, w:4, h:14, vy:-11, enemy:false}];
+    const bullets = [{x:bx, y:by, w:4, h:14, vy:-8, enemy:false}];
     if (player.tri>0) {
-      bullets.push({x:bx-14, y:by, w:4, h:14, vy:-11, vx:-1.8, enemy:false});
-      bullets.push({x:bx+14, y:by, w:4, h:14, vy:-11, vx:1.8, enemy:false});
+      bullets.push({x:bx-14, y:by, w:4, h:14, vy:-8, vx:-1.8, enemy:false});
+      bullets.push({x:bx+14, y:by, w:4, h:14, vy:-8, vx:1.8, enemy:false});
     }
     state.bullets.push(...bullets);
-    state.cooldown = player.tri>0 ? 10 : 14;
+    state.cooldown = player.tri>0 ? 14 : 18;
     beep(880, .05, 'square', .04);
   }
 
   function enemyShoot(e) {
-    state.eBullets.push({x:e.x+e.w/2-2, y:e.y+e.h, w:4, h:14, vy: 6 + Math.random()*1.5, enemy:true});
+    state.eBullets.push({x:e.x+e.w/2-2, y:e.y+e.h, w:4, h:14, vy: 4 + Math.random()*1.2, enemy:true});
   }
 
   // Powerups
@@ -231,7 +231,7 @@
     if (Math.random() < 0.12) {
       const kinds = ['life','tri','shield'];
       const kind = kinds[Math.floor(Math.random()*kinds.length)];
-      state.powerups.push({x:ex, y:ey, w:18, h:18, vy:2.2, kind});
+      state.powerups.push({x:ex, y:ey, w:18, h:18, vy:1.5, kind});
     }
   }
 
@@ -297,7 +297,7 @@
         e.anim ^= 1;
         if (e.x < state.enemyLeft || e.x + e.w > state.enemyRight) hitEdge = true;
         // chance to shoot
-        if (Math.random() < 0.02 + state.level*0.002) enemyShoot(e);
+        if (Math.random() < 0.015 + state.level*0.0015) enemyShoot(e);
       }
       if (hitEdge) {
         for (const e of state.enemies) e.y += state.enemyDrop;


### PR DESCRIPTION
## Summary
- allow header and HUD to wrap, preventing cramped layout
- slow player, enemy, and bullet speeds for smoother gameplay

## Testing
- `npm test` (fails: Could not read package.json)

------
https://chatgpt.com/codex/tasks/task_e_68bcfe336df08331bcffccececc679dd