### PR TITLE
Add speed toggle and slow default gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,11 +40,12 @@
     }
     .brand img { width: 28px; height: 28px; }
     .hud {
-      display: inline-flex; flex-wrap: wrap; gap: 16px; row-gap: 6px;
+      display: flex; flex-wrap: wrap; gap: 16px; row-gap: 6px;
       align-items: center; justify-content: center;
       font-weight: 600;
       background: rgba(255,255,255,.05);
       padding: 6px 10px; border-radius: 999px; backdrop-filter: blur(6px);
+      max-width: 100%;
     }
     @media (max-width: 600px) {
       header { justify-content: center; }
@@ -107,6 +108,7 @@
       <div>Lives: <span id="lives">3</span></div>
       <div>Level: <span id="level">1</span></div>
       <button class="btn secondary" id="muteBtn" aria-label="Toggle sound">🔊</button>
+      <button class="btn secondary" id="speedBtn">Speed: Slow</button>
       <button class="btn" id="pauseBtn">Pause</button>
     </div>
   </header>

--- a/js/game.js
+++ b/js/game.js
@@ -16,6 +16,7 @@
   const levelEl = $('#level');
   const pauseBtn = $('#pauseBtn');
   const muteBtn = $('#muteBtn');
+  const speedBtn = $('#speedBtn');
 
   // Dimensions (virtual fixed), canvas is scaled by CSS
   const W = canvas.width, H = canvas.height;
@@ -64,6 +65,7 @@
     enemyRight: W-60,
     waveCleared: false,
     gameOver: false,
+    speed: 0.5,
   };
 
   // Entities
@@ -207,6 +209,17 @@
   pauseBtn.addEventListener('click', () => togglePause());
   muteBtn.addEventListener('click', () => { muted = !muted; localStorage.setItem('invaders_muted', JSON.stringify(muted)); setMuteUI(); });
 
+  const speedModes = [
+    {label:'Slow', value:0.5},
+    {label:'Fast', value:1},
+  ];
+  let speedIndex = 0;
+  speedBtn.addEventListener('click', () => {
+    speedIndex = (speedIndex + 1) % speedModes.length;
+    state.speed = speedModes[speedIndex].value;
+    speedBtn.textContent = 'Speed: ' + speedModes[speedIndex].label;
+  });
+
   function togglePause() {
     if (state.gameOver) { resetGame(); return; }
     state.playing = !state.playing;
@@ -273,15 +286,15 @@
 
   function update(dt) {
     // cooldowns
-    if (state.cooldown>0) state.cooldown -= 1;
-    if (player.inv>0) player.inv -= 1;
-    if (player.tri>0) player.tri -= 1;
+    if (state.cooldown>0) state.cooldown -= state.speed;
+    if (player.inv>0) player.inv -= state.speed;
+    if (player.tri>0) player.tri -= state.speed;
 
     // player move
     const movingLeft = keys.left || state.touch.left;
     const movingRight = keys.right || state.touch.right;
-    if (movingLeft) player.x -= player.speed;
-    if (movingRight) player.x += player.speed;
+    if (movingLeft) player.x -= player.speed * state.speed;
+    if (movingRight) player.x += player.speed * state.speed;
     player.x = Math.max(6, Math.min(W - player.w - 6, player.x));
 
     // fire
@@ -289,17 +302,17 @@
 
     // bullets
     for (const b of state.bullets) {
-      b.y += b.vy;
-      if (b.vx) b.x += b.vx;
+      b.y += b.vy * state.speed;
+      if (b.vx) b.x += b.vx * state.speed;
     }
     state.bullets = state.bullets.filter(b => b.y + b.h > 0 && b.y < H && b.x>-10 && b.x<W+10);
 
     // enemy bullets
-    for (const b of state.eBullets) b.y += b.vy;
+    for (const b of state.eBullets) b.y += b.vy * state.speed;
     state.eBullets = state.eBullets.filter(b => b.y < H+20);
 
     // enemies step (march)
-    state.enemyStepTimer += dt;
+    state.enemyStepTimer += dt * state.speed;
     if (state.enemyStepTimer >= state.enemySpeed) {
       state.enemyStepTimer = 0;
       let hitEdge = false;
@@ -387,7 +400,7 @@
     }
 
     // powerups
-    for (const p of state.powerups) p.y += p.vy;
+    for (const p of state.powerups) p.y += p.vy * state.speed;
     state.powerups = state.powerups.filter(p => p.y < H+20);
     for (const p of state.powerups) {
       if (rect(p, player)) { applyPowerup(p.kind); p._dead = true; }
@@ -395,7 +408,7 @@
     state.powerups = state.powerups.filter(p => !p._dead);
 
     // particles
-    for (const p of state.particles) { p.x += p.vx; p.y += p.vy; p.life -= 1; }
+    for (const p of state.particles) { p.x += p.vx * state.speed; p.y += p.vy * state.speed; p.life -= state.speed; }
     state.particles = state.particles.filter(p => p.life>0);
 
     // next wave


### PR DESCRIPTION
## Summary
- Slow default game speed and scale movement to speed setting
- Add Speed button in HUD to toggle between Slow and Fast modes
- Improve HUD layout so all header info stays visible

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd0352227c83319d6269399c695551