### PR TITLE
Add leaderboard and game over save modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,11 +88,11 @@
       border: 1px solid rgba(255,255,255,.1);
     }
     .hide { display: none !important; }
-    #welcomeModal {
+    #welcomeModal, #gameOverModal, #leaderboardModal {
       position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
       background: rgba(0,0,0,.8); z-index: 20;
     }
-    #welcomeModal .content {
+    #welcomeModal .content, #gameOverModal .content, #leaderboardModal .content {
       background: rgba(15,23,42,.9); padding: 24px; border-radius: 12px; text-align: center;
     }
     #help {
@@ -119,6 +119,7 @@
       <button class="btn" id="startBtn">Start</button>
       <button class="btn hide" id="pauseBtn">Pause</button>
       <button class="btn hide" id="resumeBtn">Resume</button>
+      <button class="btn secondary" id="leaderboardBtn">Leaderboard</button>
     </div>
   </header>
 
@@ -139,6 +140,24 @@
 
       <button id="closeModalBtn" class="btn secondary">Close</button>
 
+    </div>
+  </div>
+
+  <div id="gameOverModal" class="hide">
+    <div class="content">
+      <h2>Game Over</h2>
+      <p>Your Score: <span id="finalScore">0</span></p>
+      <p>Save to leaderboard?</p>
+      <button id="saveScoreBtn" class="btn">Yes</button>
+      <button id="dismissScoreBtn" class="btn secondary">No</button>
+    </div>
+  </div>
+
+  <div id="leaderboardModal" class="hide">
+    <div class="content">
+      <h2>Leaderboard</h2>
+      <ol id="leaderboardList"></ol>
+      <button id="closeLeaderboardBtn" class="btn secondary">Close</button>
     </div>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,14 @@
   const muteBtn = $('#muteBtn');
   const speedBtn = $('#speedBtn');
   const startBtn = $('#startBtn');
+  const leaderboardBtn = $('#leaderboardBtn');
+  const gameOverModal = $('#gameOverModal');
+  const saveScoreBtn = $('#saveScoreBtn');
+  const dismissScoreBtn = $('#dismissScoreBtn');
+  const finalScoreEl = $('#finalScore');
+  const leaderboardModal = $('#leaderboardModal');
+  const closeLeaderboardBtn = $('#closeLeaderboardBtn');
+  const leaderboardList = $('#leaderboardList');
 
   // Dimensions (virtual fixed), canvas is scaled by CSS
   const W = canvas.width, H = canvas.height;
@@ -78,6 +86,33 @@
 
   };
 
+  function getLeaderboard() {
+    return JSON.parse(localStorage.getItem('invaders_leaderboard')||'[]');
+  }
+
+  function saveToLeaderboard(name, score) {
+    const board = getLeaderboard();
+    board.push({name, score});
+    board.sort((a,b) => b.score - a.score);
+    localStorage.setItem('invaders_leaderboard', JSON.stringify(board.slice(0,10)));
+  }
+
+  function renderLeaderboard() {
+    const board = getLeaderboard();
+    leaderboardList.innerHTML = board.length ?
+      board.map(e => `<li>${e.name} - ${e.score}</li>`).join('') :
+      '<li>No scores yet</li>';
+  }
+
+  function showGameOver() {
+    finalScoreEl.textContent = state.score;
+    gameOverModal.classList.remove('hide');
+  }
+
+  function hideGameOver() {
+    gameOverModal.classList.add('hide');
+  }
+
   function rect(a,b) {
     return !(a.x+a.w < b.x || b.x+b.w < a.x || a.y+a.h < b.y || b.y+b.h < a.y);
   }
@@ -127,6 +162,7 @@
     player.inv = 0; player.tri = 0; player.x = W/2;
     spawnShields();
     makeWave(state.level);
+    hideGameOver();
   }
 
   // Drawing helpers
@@ -226,6 +262,17 @@
     state.started = true;
     resumeGame();
   });
+  leaderboardBtn.addEventListener('click', () => {
+    renderLeaderboard();
+    leaderboardModal.classList.remove('hide');
+  });
+  closeLeaderboardBtn.addEventListener('click', () => leaderboardModal.classList.add('hide'));
+  saveScoreBtn.addEventListener('click', () => {
+    const name = prompt('Enter your name:');
+    if (name) saveToLeaderboard(name, state.score);
+    hideGameOver();
+  });
+  dismissScoreBtn.addEventListener('click', () => hideGameOver());
   muteBtn.addEventListener('click', () => { muted = !muted; localStorage.setItem('invaders_muted', JSON.stringify(muted)); setMuteUI(); });
 
   const speedModes = [
@@ -429,6 +476,7 @@
               state.hiScore = state.score;
               localStorage.setItem('invaders_hi', state.hiScore);
             }
+            showGameOver();
           }
           break;
         }
@@ -444,6 +492,7 @@
         pauseBtn.classList.remove('hide');
         resumeBtn.classList.add('hide');
         beep(100,.2,'square',.08);
+        showGameOver();
         break;
       }
     }


### PR DESCRIPTION
## Summary
- Prompt players to save scores on game over and persist top results locally
- Add leaderboard modal with top ten scores and HUD button to view it

## Testing
- `node --check js/game.js`
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68bdef22d1b08331852fb4dadd1e7cbe