### PR TITLE
Add leaderboard and game over save modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,12 +88,20 @@
       border: 1px solid rgba(255,255,255,.1);
     }
     .hide { display: none !important; }
-    #welcomeModal {
+    #welcomeModal, #gameOverModal, #leaderboardModal, #saveScoreModal {
       position: fixed; inset: 0; display: flex; align-items: center; justify-content: center;
       background: rgba(0,0,0,.8); z-index: 20;
     }
-    #welcomeModal .content {
+    #welcomeModal .content, #gameOverModal .content, #leaderboardModal .content, #saveScoreModal .content {
       background: rgba(15,23,42,.9); padding: 24px; border-radius: 12px; text-align: center;
+    }
+    #saveScoreModal input {
+      background: rgba(255,255,255,.1); border: 1px solid rgba(255,255,255,.2);
+      padding: 8px 12px; border-radius: 8px; color: var(--fg);
+      width: 100%; box-sizing: border-box;
+    }
+    #leaderboardList {
+      text-align: left; margin: 0; padding-left: calc(var(--pad) * 2);
     }
     #help {
       position: fixed; top: 56px; right: 16px; max-width: 360px;
@@ -119,6 +127,7 @@
       <button class="btn" id="startBtn">Start</button>
       <button class="btn hide" id="pauseBtn">Pause</button>
       <button class="btn hide" id="resumeBtn">Resume</button>
+      <button class="btn secondary" id="leaderboardBtn">Leaderboard</button>
     </div>
   </header>
 
@@ -139,6 +148,35 @@
 
       <button id="closeModalBtn" class="btn secondary">Close</button>
 
+    </div>
+  </div>
+
+  <div id="gameOverModal" class="hide">
+    <div class="content">
+      <h2>Game Over</h2>
+      <p>Your Score: <span id="finalScore">0</span></p>
+      <p>Save to leaderboard?</p>
+      <button id="saveScoreBtn" class="btn">Yes</button>
+      <button id="dismissScoreBtn" class="btn secondary">No</button>
+    </div>
+  </div>
+
+  <div id="saveScoreModal" class="hide">
+    <div class="content">
+      <h2>Enter Name</h2>
+      <input id="playerNameInput" type="text" placeholder="Your name" />
+      <div style="margin-top:16px; display:flex; gap:12px; justify-content:center;">
+        <button id="submitNameBtn" class="btn">Save</button>
+        <button id="cancelNameBtn" class="btn secondary">Cancel</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="leaderboardModal" class="hide">
+    <div class="content">
+      <h2>Leaderboard</h2>
+      <ol id="leaderboardList"></ol>
+      <button id="closeLeaderboardBtn" class="btn secondary">Close</button>
     </div>
   </div>
 

--- a/js/game.js
+++ b/js/game.js
@@ -19,6 +19,18 @@
   const muteBtn = $('#muteBtn');
   const speedBtn = $('#speedBtn');
   const startBtn = $('#startBtn');
+  const leaderboardBtn = $('#leaderboardBtn');
+  const gameOverModal = $('#gameOverModal');
+  const saveScoreBtn = $('#saveScoreBtn');
+  const dismissScoreBtn = $('#dismissScoreBtn');
+  const finalScoreEl = $('#finalScore');
+  const leaderboardModal = $('#leaderboardModal');
+  const closeLeaderboardBtn = $('#closeLeaderboardBtn');
+  const leaderboardList = $('#leaderboardList');
+  const saveScoreModal = $('#saveScoreModal');
+  const playerNameInput = $('#playerNameInput');
+  const submitNameBtn = $('#submitNameBtn');
+  const cancelNameBtn = $('#cancelNameBtn');
 
   // Dimensions (virtual fixed), canvas is scaled by CSS
   const W = canvas.width, H = canvas.height;
@@ -78,6 +90,33 @@
 
   };
 
+  function getLeaderboard() {
+    return JSON.parse(localStorage.getItem('invaders_leaderboard')||'[]');
+  }
+
+  function saveToLeaderboard(name, score) {
+    const board = getLeaderboard();
+    board.push({name, score});
+    board.sort((a,b) => b.score - a.score);
+    localStorage.setItem('invaders_leaderboard', JSON.stringify(board.slice(0,10)));
+  }
+
+  function renderLeaderboard() {
+    const board = getLeaderboard();
+    leaderboardList.innerHTML = board.length ?
+      board.map(e => `<li>${e.name} - ${e.score}</li>`).join('') :
+      '<li>No scores yet</li>';
+  }
+
+  function showGameOver() {
+    finalScoreEl.textContent = state.score;
+    gameOverModal.classList.remove('hide');
+  }
+
+  function hideGameOver() {
+    gameOverModal.classList.add('hide');
+  }
+
   function rect(a,b) {
     return !(a.x+a.w < b.x || b.x+b.w < a.x || a.y+a.h < b.y || b.y+b.h < a.y);
   }
@@ -127,6 +166,7 @@
     player.inv = 0; player.tri = 0; player.x = W/2;
     spawnShields();
     makeWave(state.level);
+    hideGameOver();
   }
 
   // Drawing helpers
@@ -226,6 +266,28 @@
     state.started = true;
     resumeGame();
   });
+  leaderboardBtn.addEventListener('click', () => {
+    renderLeaderboard();
+    leaderboardModal.classList.remove('hide');
+  });
+  closeLeaderboardBtn.addEventListener('click', () => leaderboardModal.classList.add('hide'));
+  saveScoreBtn.addEventListener('click', () => {
+    hideGameOver();
+    playerNameInput.value = '';
+    saveScoreModal.classList.remove('hide');
+    playerNameInput.focus();
+  });
+  submitNameBtn.addEventListener('click', () => {
+    const name = playerNameInput.value.trim();
+    if (name) {
+      saveToLeaderboard(name, state.score);
+      renderLeaderboard();
+    }
+    saveScoreModal.classList.add('hide');
+  });
+  cancelNameBtn.addEventListener('click', () => saveScoreModal.classList.add('hide'));
+  playerNameInput.addEventListener('keydown', e => { if (e.key === 'Enter') submitNameBtn.click(); });
+  dismissScoreBtn.addEventListener('click', () => hideGameOver());
   muteBtn.addEventListener('click', () => { muted = !muted; localStorage.setItem('invaders_muted', JSON.stringify(muted)); setMuteUI(); });
 
   const speedModes = [
@@ -429,6 +491,7 @@
               state.hiScore = state.score;
               localStorage.setItem('invaders_hi', state.hiScore);
             }
+            showGameOver();
           }
           break;
         }
@@ -444,6 +507,7 @@
         pauseBtn.classList.remove('hide');
         resumeBtn.classList.add('hide');
         beep(100,.2,'square',.08);
+        showGameOver();
         break;
       }
     }


### PR DESCRIPTION
## Summary
- Prompt players to save scores on game over and persist top results locally
- Add leaderboard modal with top ten scores and HUD button to view it
- Ask for player name via modal before saving score
- Align leaderboard names and scores to the left for better readability

## Testing
- `node --check js/game.js`
- `npm test` *(fails: enoent: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bdef22d1b08331852fb4dadd1e7cbe